### PR TITLE
fix: input min-width error and tags input value may null

### DIFF
--- a/src/input/input.component.scss
+++ b/src/input/input.component.scss
@@ -5,6 +5,8 @@
 .aui-input {
   display: inline-block;
   width: 100%;
+  // firefox has default min-width, override it for flex shrinking
+  min-width: 0;
   border: $input-border-style $input-border-width $input-border-color;
   border-radius: $input-border-radius;
   background-color: $input-bg-color;

--- a/src/input/tags-input/tags-input.component.html
+++ b/src/input/tags-input/tags-input.component.html
@@ -4,7 +4,7 @@
   (click)="inputRef.focus()"
 >
   <span
-    [hidden]="(value$ | async).length || inputRef.value.length"
+    [hidden]="(value$ | async)?.length || inputRef.value.length"
     [class]="bem.element('placeholder')"
   >
     {{ placeholder }}


### PR DESCRIPTION
tags-input如果采用ngModel形式，会在control设置具体value前，预先发一个null值，导致(value$ | async).length出错