### PR TITLE
fix: aui-platform-nav title not display fix

### DIFF
--- a/src/nav-menu/nav-item-group/nav-item-group.component.ts
+++ b/src/nav-menu/nav-item-group/nav-item-group.component.ts
@@ -28,7 +28,7 @@ export class NavItemGroupTitleDirective {
   preserveWhitespaces: false,
 })
 export class NavItemGroupComponent {
-  @ContentChild(NavItemGroupTitleDirective, { static: true })
+  @ContentChild(NavItemGroupTitleDirective)
   title: NavItemGroupTitleDirective;
 
   @ContentChildren(forwardRef(() => NavItemComponent))

--- a/src/nav-menu/platform-nav/__snapshots__/platform-nav.component.spec.ts.snap
+++ b/src/nav-menu/platform-nav/__snapshots__/platform-nav.component.spec.ts.snap
@@ -30,6 +30,12 @@ exports[`PlatformNavComponent should render correct template 1`] = `
                   class="aui-nav-item-group"
                 >
                   
+                  <div
+                    class="aui-nav-item-group__title"
+                  >
+                    
+                     group 1 
+                  </div>
                   
                   <aui-nav-item-li>
                     <div
@@ -151,6 +157,12 @@ exports[`PlatformNavComponent should render correct template 1`] = `
                   class="aui-nav-item-group"
                 >
                   
+                  <div
+                    class="aui-nav-item-group__title"
+                  >
+                    
+                     group 2 
+                  </div>
                   
                   <aui-nav-item-li>
                     <div


### PR DESCRIPTION
fix aui-platform-nav 通过groups传入左导航数据时 title 不显示的bug