### PR TITLE
fix: remove form item width

### DIFF
--- a/.changeset/shiny-chicken-behave.md
+++ b/.changeset/shiny-chicken-behave.md
@@ -1,5 +1,0 @@
----
-"@alauda/ui": patch
----
-
-feat: support medium width for table item

--- a/.changeset/thick-windows-smell.md
+++ b/.changeset/thick-windows-smell.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+feat: String input support for the form item with 'large' | 'small' | 'medium'

--- a/src/form/__snapshots__/form.component.spec.ts.snap
+++ b/src/form/__snapshots__/form.component.spec.ts.snap
@@ -30,7 +30,7 @@ exports[`FormComponent should match snapshot 1`] = `
           class="aui-form-item__container"
         >
           <div
-            class="aui-form-item__content aui-form-item__content--medium"
+            class="aui-form-item__content"
           >
             <input
               aui-input=""
@@ -101,7 +101,7 @@ exports[`FormComponent should match snapshot 2`] = `
           class="aui-form-item__container"
         >
           <div
-            class="aui-form-item__content aui-form-item__content--medium"
+            class="aui-form-item__content"
           >
             <input
               aui-input=""

--- a/src/form/form-item/form-item.component.ts
+++ b/src/form/form-item/form-item.component.ts
@@ -48,7 +48,7 @@ export class FormItemComponent implements AfterContentInit, OnDestroy {
   labelWidth = 'auto';
 
   @Input()
-  width: FormItemWidth = FormItemWidth.Medium;
+  width: FormItemWidth;
 
   @Input()
   labelPosition: LabelPosition = LabelPosition.Right;


### PR DESCRIPTION
这里思考过后还是不应该在aui里去决定使用场景的默认item width，可能也会对现有项目特殊组件产生影响，所以决定去掉默认值。
对于项目中大部分表单元素都是medium的长度的情况，我觉得可以在项目的通用样式中添加全局的初始值就可以了