### PR TITLE
fix: tree-select `labelFn` takes higher priority than `label`

### DIFF
--- a/.changeset/ninety-pens-wink.md
+++ b/.changeset/ninety-pens-wink.md
@@ -1,0 +1,5 @@
+---
+"@alauda/ui": patch
+---
+
+fix: tree-select `labelFn` takes higher priority than `label`

--- a/src/tree-select/tree-select.component.ts
+++ b/src/tree-select/tree-select.component.ts
@@ -278,8 +278,8 @@ export class TreeSelectComponent<T = unknown> extends CommonFormControl<T> {
 
   private getLabelFromNode(node: TreeNode<T>) {
     return (
-      node.label ||
       this.labelFn?.(node.value) ||
+      node.label ||
       coerceString(this.trackFn(node.value))
     );
   }


### PR DESCRIPTION
获取label顺序错误导致labelFn不生效